### PR TITLE
🚧 WIP Modify podspec

### DIFF
--- a/BitcoinCashKit.podspec
+++ b/BitcoinCashKit.podspec
@@ -1,28 +1,28 @@
 Pod::Spec.new do |spec|
-  spec.name = 'BitcoinKit'
+  spec.name = 'BitcoinCashKit'
   spec.version = '0.1.2'
   spec.summary = 'Bitcoin cash protocol toolkit for Swift'
   spec.description = <<-DESC
                        The BitcoinCashKit library is a Swift implementation of the Bitcoin cash protocol. This library is a fork of Katsumi Kishikawa's original BitcoinKit library aimed at supporting the Bitcoin cash eco-system. It allows maintaining a wallet and sending/receiving transactions without needing a full blockchain node. It comes with a simple wallet app showing how to use it.
                        ```
                     DESC
-  spec.homepage = 'https://github.com/BitcoinCashKit/BitcoinKit'
+  spec.homepage = 'https://github.com/BitcoinCashKit/BitcoinCashKit'
   spec.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
   spec.author = { 'BitcoinCashKit developers' => 'usatie@yenom.tech' }
 
   spec.requires_arc = true
-  spec.source = { git: 'https://github.com/BitcoinCashKit/BitcoinKit.git', tag: "cash-v#{spec.version}" }
-  spec.source_files = 'BitcoinKit/**/*.{h,m,swift}'
-  spec.private_header_files = 'BitcoinKit/**/BitcoinKitPrivate.h'
-  spec.module_map = 'BitcoinKit/BitcoinKit.modulemap'
+  spec.source = { git: 'https://github.com/BitcoinCashKit/BitcoinCashKit.git', tag: "cash-v#{spec.version}" }
+  spec.source_files = 'BitcoinCashKit/**/*.{h,m,swift}'
+  spec.private_header_files = 'BitcoinCashKit/**/BitcoinCashKitPrivate.h'
+  spec.module_map = 'BitcoinCashKit/BitcoinCashKit.modulemap'
   spec.ios.deployment_target = '8.0'
   spec.swift_version = '4.1'
 
   spec.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',
                                'APPLICATION_EXTENSION_API_ONLY' => 'YES',
-                               'SWIFT_INCLUDE_PATHS' => '${PODS_ROOT}/BitcoinKit/Libraries',
-                               'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/BitcoinKit/Libraries/openssl/include" "${PODS_ROOT}/BitcoinKit/Libraries/secp256k1/include"',
-                               'LIBRARY_SEARCH_PATHS' => '"${PODS_ROOT}/BitcoinKit/Libraries/openssl/lib" "${PODS_ROOT}/BitcoinKit/Libraries/secp256k1/lib"' }
+                               'SWIFT_INCLUDE_PATHS' => '${PODS_ROOT}/BitcoinCashKit/Libraries',
+                               'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/BitcoinCashKit/Libraries/openssl/include" "${PODS_ROOT}/BitcoinCashKit/Libraries/secp256k1/include"',
+                               'LIBRARY_SEARCH_PATHS' => '"${PODS_ROOT}/BitcoinCashKit/Libraries/openssl/lib" "${PODS_ROOT}/BitcoinCashKit/Libraries/secp256k1/lib"' }
   spec.preserve_paths = ['setup', 'Libraries']
   spec.prepare_command = 'sh setup/build_libraries.sh'
 end

--- a/BitcoinCashKit.xcodeproj/project.pbxproj
+++ b/BitcoinCashKit.xcodeproj/project.pbxproj
@@ -838,7 +838,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 27AEDK3C9F;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/Libraries/crypto/include";
+				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = BitcoinCashKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -858,7 +858,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 27AEDK3C9F;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/Libraries/crypto/include";
+				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = BitcoinCashKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/BitcoinKit.podspec
+++ b/BitcoinKit.podspec
@@ -1,23 +1,22 @@
 Pod::Spec.new do |spec|
   spec.name = 'BitcoinKit'
   spec.version = '0.1.2'
-  spec.summary = 'Bitcoin protocol toolkit for Swift'
+  spec.summary = 'Bitcoin cash protocol toolkit for Swift'
   spec.description = <<-DESC
-                       BitcoinKit implements Bitcoin protocol in Swift. It is an implementation of the Bitcoin SPV protocol written (almost) entirely in swift.
+                       The BitcoinCashKit library is a Swift implementation of the Bitcoin cash protocol. This library is a fork of Katsumi Kishikawa's original BitcoinKit library aimed at supporting the Bitcoin cash eco-system. It allows maintaining a wallet and sending/receiving transactions without needing a full blockchain node. It comes with a simple wallet app showing how to use it.
                        ```
                     DESC
-  spec.homepage = 'https://github.com/kishikawakatsumi/BitcoinKit'
+  spec.homepage = 'https://github.com/BitcoinCashKit/BitcoinKit'
   spec.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  spec.author = { 'Kishikawa Katsumi' => 'kishikawakatsumi@mac.com' }
-  spec.social_media_url = 'https://twitter.com/k_katsumi'
+  spec.author = { 'BitcoinCashKit developers' => 'usatie@yenom.tech' }
 
   spec.requires_arc = true
-  spec.source = { git: 'https://github.com/kishikawakatsumi/BitcoinKit.git', tag: "v#{spec.version}" }
+  spec.source = { git: 'https://github.com/BitcoinCashKit/BitcoinKit.git', tag: "cash-v#{spec.version}" }
   spec.source_files = 'BitcoinKit/**/*.{h,m,swift}'
-  spec.private_header_files = 'BitcoinKit/**/BitcoinKitInternal.h'
+  spec.private_header_files = 'BitcoinKit/**/BitcoinKitPrivate.h'
   spec.module_map = 'BitcoinKit/BitcoinKit.modulemap'
   spec.ios.deployment_target = '8.0'
-  spec.swift_version = '4.0'
+  spec.swift_version = '4.1'
 
   spec.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',
                                'APPLICATION_EXTENSION_API_ONLY' => 'YES',


### PR DESCRIPTION
`pod lib lint` cannot pass.

```
** BUILD FAILED **


The following build commands failed:
	CompileSwift normal i386
	CompileSwiftSources normal i386 com.apple.xcode.tools.swift.compiler
(2 failures)
   Testing with xcodebuild.
 -> BitcoinCashKit (0.1.2)
    - ERROR | [iOS] xcodebuild: Returned an unsuccessful exit code.
    - ERROR | [iOS] xcodebuild:  /Users/shunusami/Bitcoin/swift/BitcoinCashKit/BitcoinCashKit/Crypto.swift:27:8: error: no such module 'secp256k1'

[!] BitcoinCashKit did not pass validation, due to 2 errors.
You can use the `--no-clean` option to inspect any issue.

/Users/shunusami/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cocoapods-1.4.0/lib/cocoapods/command/lib/lint.rb:85:in `block in run'
/Users/shunusami/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cocoapods-1.4.0/lib/cocoapods/command/lib/lint.rb:54:in `each'
/Users/shunusami/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cocoapods-1.4.0/lib/cocoapods/command/lib/lint.rb:54:in `run'
/Users/shunusami/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/claide-1.0.2/lib/claide/command.rb:334:in `run'
/Users/shunusami/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cocoapods-1.4.0/lib/cocoapods/command.rb:52:in `run'
/Users/shunusami/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cocoapods-1.4.0/bin/pod:55:in `<top (required)>'
/Users/shunusami/.anyenv/envs/rbenv/versions/2.3.1/bin/pod:23:in `load'
/Users/shunusami/.anyenv/envs/rbenv/versions/2.3.1/bin/pod:23:in `<main>'
```