### PR TITLE
Added tests for OpCodeFactory

### DIFF
--- a/BitcoinCashKit.xcodeproj/project.pbxproj
+++ b/BitcoinCashKit.xcodeproj/project.pbxproj
@@ -100,9 +100,8 @@
 		6E20AED32112C7DA008A9810 /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20AED22112C7DA008A9810 /* TransactionTests.swift */; };
 		6E20AED52112C8F9008A9810 /* BloomFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20AED42112C8F9008A9810 /* BloomFilterTests.swift */; };
 		6E20AED72112D417008A9810 /* MurmurHashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20AED62112D417008A9810 /* MurmurHashTests.swift */; };
+		6E797C452116C8A5003BEDFD /* OpCodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E797C442116C8A5003BEDFD /* OpCodeFactoryTests.swift */; };
 		6EE789DB2112C1E500EAB620 /* CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE789DA2112C1E500EAB620 /* CryptoTests.swift */; };
-		29F5D1E421106772007DA3BF /* BigNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1E321106772007DA3BF /* BigNumberTests.swift */; };
-		29F5D1E6211068E8007DA3BF /* BigNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1E5211068E8007DA3BF /* BigNumber.swift */; };
 		CF432AF220F0CF9100AD4020 /* Base58Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF432AF120F0CF9100AD4020 /* Base58Tests.swift */; };
 		CF432AF420F0DFAC00AD4020 /* Bech32Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF432AF320F0DFAC00AD4020 /* Bech32Tests.swift */; };
 		CF432AF620F0ED4500AD4020 /* AddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF432AF520F0ED4500AD4020 /* AddressTests.swift */; };
@@ -315,6 +314,7 @@
 				6E20AED22112C7DA008A9810 /* TransactionTests.swift */,
 				6E20AED42112C8F9008A9810 /* BloomFilterTests.swift */,
 				6E20AED62112D417008A9810 /* MurmurHashTests.swift */,
+				6E797C442116C8A5003BEDFD /* OpCodeFactoryTests.swift */,
 			);
 			path = BitcoinCashKitTests;
 			sourceTree = "<group>";
@@ -691,6 +691,7 @@
 				CF432AF620F0ED4500AD4020 /* AddressTests.swift in Sources */,
 				6E20AED32112C7DA008A9810 /* TransactionTests.swift in Sources */,
 				6E20AED72112D417008A9810 /* MurmurHashTests.swift in Sources */,
+				6E797C452116C8A5003BEDFD /* OpCodeFactoryTests.swift in Sources */,
 				CF432AFC20F25E0000AD4020 /* TestHelpersTests.swift in Sources */,
 				CFA290702101CDCA001A1BAB /* ScriptTests.swift in Sources */,
 				6E20AECF2112C66C008A9810 /* HDKeyChainTests.swift in Sources */,

--- a/BitcoinCashKit.xcodeproj/project.pbxproj
+++ b/BitcoinCashKit.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		29E1ED73210ECD35007F4627 /* OP_CHECKMULTISIG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E1ED72210ECD35007F4627 /* OP_CHECKMULTISIG.swift */; };
 		29E1ED75210EF071007F4627 /* OP_CHECKMULTISIGVERIFY.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E1ED74210EF071007F4627 /* OP_CHECKMULTISIGVERIFY.swift */; };
 		29F5D1E02110495F007DA3BF /* OpCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1DF2110495F007DA3BF /* OpCodeTests.swift */; };
+		29F5D1E421106772007DA3BF /* BigNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1E321106772007DA3BF /* BigNumberTests.swift */; };
+		29F5D1E6211068E8007DA3BF /* BigNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1E5211068E8007DA3BF /* BigNumber.swift */; };
 		6E20AEC72112C290008A9810 /* PrivateKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20AEC62112C290008A9810 /* PrivateKeyTests.swift */; };
 		6E20AEC92112C31A008A9810 /* LegacyAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20AEC82112C31A008A9810 /* LegacyAddressTests.swift */; };
 		6E20AECB2112C434008A9810 /* HDPrivateKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20AECA2112C434008A9810 /* HDPrivateKeyTests.swift */; };
@@ -213,6 +215,8 @@
 		29E1ED72210ECD35007F4627 /* OP_CHECKMULTISIG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OP_CHECKMULTISIG.swift; sourceTree = "<group>"; };
 		29E1ED74210EF071007F4627 /* OP_CHECKMULTISIGVERIFY.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OP_CHECKMULTISIGVERIFY.swift; sourceTree = "<group>"; };
 		29F5D1DF2110495F007DA3BF /* OpCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpCodeTests.swift; sourceTree = "<group>"; };
+		29F5D1E321106772007DA3BF /* BigNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigNumberTests.swift; sourceTree = "<group>"; };
+		29F5D1E5211068E8007DA3BF /* BigNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigNumber.swift; sourceTree = "<group>"; };
 		6E20AEC62112C290008A9810 /* PrivateKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateKeyTests.swift; sourceTree = "<group>"; };
 		6E20AEC82112C31A008A9810 /* LegacyAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyAddressTests.swift; sourceTree = "<group>"; };
 		6E20AECA2112C434008A9810 /* HDPrivateKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HDPrivateKeyTests.swift; sourceTree = "<group>"; };
@@ -222,9 +226,8 @@
 		6E20AED22112C7DA008A9810 /* TransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTests.swift; sourceTree = "<group>"; };
 		6E20AED42112C8F9008A9810 /* BloomFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloomFilterTests.swift; sourceTree = "<group>"; };
 		6E20AED62112D417008A9810 /* MurmurHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MurmurHashTests.swift; sourceTree = "<group>"; };
+		6E797C442116C8A5003BEDFD /* OpCodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpCodeFactoryTests.swift; sourceTree = "<group>"; };
 		6EE789DA2112C1E500EAB620 /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
-		29F5D1E321106772007DA3BF /* BigNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigNumberTests.swift; sourceTree = "<group>"; };
-		29F5D1E5211068E8007DA3BF /* BigNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigNumber.swift; sourceTree = "<group>"; };
 		CF432AF120F0CF9100AD4020 /* Base58Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base58Tests.swift; sourceTree = "<group>"; };
 		CF432AF320F0DFAC00AD4020 /* Bech32Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bech32Tests.swift; sourceTree = "<group>"; };
 		CF432AF520F0ED4500AD4020 /* AddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressTests.swift; sourceTree = "<group>"; };

--- a/BitcoinCashKit/Core/Scripts/OpCodeFactory.swift
+++ b/BitcoinCashKit/Core/Scripts/OpCodeFactory.swift
@@ -95,7 +95,7 @@ public struct OpCodeFactory {
         case OpCode.OP_0:
             return 0
         case (OpCode.OP_1)...(OpCode.OP_16):
-            return Int(opcode.value - OpCode.OP_1.value - 1)
+            return Int(opcode.value - OpCode.OP_1.value + 1)
         default:
             return Int.max
         }

--- a/BitcoinCashKitTests/OpCodeFactoryTests.swift
+++ b/BitcoinCashKitTests/OpCodeFactoryTests.swift
@@ -1,0 +1,72 @@
+//
+//  OpCodeTests.swift
+//
+//  Copyright © 2018 BitcoinCashKit developers
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+@testable import BitcoinCashKit
+
+class OpCodeFactoryTests: XCTestCase {
+    func testGetWithValue() {
+        assert(OpCodeFactory.get(with: 0x00), OpCode.OP_0)
+        assert(OpCodeFactory.get(with: 0x4c), OpCode.OP_PUSHDATA1)
+        assert(OpCodeFactory.get(with: 0x4f), OpCode.OP_1NEGATE)
+        assert(OpCodeFactory.get(with: 0x51), OpCode.OP_1)
+        assert(OpCodeFactory.get(with: 0xa9), OpCode.OP_HASH160)
+        assert(OpCodeFactory.get(with: 0xac), OpCode.OP_CHECKSIG)
+        assert(OpCodeFactory.get(with: 0xff), OpCode.OP_INVALIDOPCODE)
+    }
+    
+    func testGetWithName() {
+        assert(OpCodeFactory.get(with: "OP_0"), OpCode.OP_0)
+        assert(OpCodeFactory.get(with: "OP_PUSHDATA1"), OpCode.OP_PUSHDATA1)
+        assert(OpCodeFactory.get(with: "OP_1NEGATE"), OpCode.OP_1NEGATE)
+        assert(OpCodeFactory.get(with: "OP_1"), OpCode.OP_1)
+        assert(OpCodeFactory.get(with: "OP_HASH160"), OpCode.OP_HASH160)
+        assert(OpCodeFactory.get(with: "OP_CHECKSIG"), OpCode.OP_CHECKSIG)
+        assert(OpCodeFactory.get(with: "OP_INVALIDOPCODE"), OpCode.OP_INVALIDOPCODE)
+    }
+    
+    func testOpCodeForSmallInteger() {
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: -1), OpCode.OP_1NEGATE)
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: 0), OpCode.OP_0)
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: 1), OpCode.OP_1)
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: 8), OpCode.OP_8)
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: 16), OpCode.OP_16)
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: 17), OpCode.OP_INVALIDOPCODE)
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: Int.min), OpCode.OP_INVALIDOPCODE)
+        assert(OpCodeFactory.opcodeForSmallInteger(smallInteger: Int.max), OpCode.OP_INVALIDOPCODE)
+    }
+    
+    func testSmallIntegerFromOpcode() {
+        XCTAssertEqual(OpCodeFactory.smallIntegerFromOpcode(opcode: OpCode.OP_1NEGATE), -1)
+        XCTAssertEqual(OpCodeFactory.smallIntegerFromOpcode(opcode: OpCode.OP_0), 0)
+        XCTAssertEqual(OpCodeFactory.smallIntegerFromOpcode(opcode: OpCode.OP_1), 1)
+        XCTAssertEqual(OpCodeFactory.smallIntegerFromOpcode(opcode: OpCode.OP_16), 16)
+        XCTAssertEqual(OpCodeFactory.smallIntegerFromOpcode(opcode: OpCode.OP_INVALIDOPCODE), Int.max)
+    }
+    
+    private func assert(_ lhs: OpCodeProtocol, _ rhs: OpCodeProtocol) {
+        XCTAssertEqual(lhs.name, rhs.name)
+        XCTAssertEqual(lhs.value, rhs.value)
+    }
+}


### PR DESCRIPTION
close https://github.com/BitcoinCashKit/BitcoinCashKit/issues/239

@usatie 
Hi!
I added tests for OpCodeFactory.
When I wrote tests, I found implementation miss.
It is in smallIntegerFromOpcode in OpCodeFactory.swift.

The code is below.
```swift
Int(opcode.value - OpCode.OP_1.value - 1)
```

The code describes that when OpCode.OP_1 is passed as argument, it becomes `Int(0 - 1)`.
So, it becomes UInt(0) - 1 and it will EXC_BAD_INSTRUCTION error.

I fixed it like below.
```swift
Int(opcode.value - OpCode.OP_1.value + 1)
```

Would you confirm it?