### PR TITLE
♻️ Refactor opcode protocol

### DIFF
--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_0NOTEQUAL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_0NOTEQUAL.swift
@@ -29,8 +29,7 @@ public struct OP0NotEqual: OpCodeProtocol {
     public var name: String { return "OP_0NOTEQUAL" }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_1ADD.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_1ADD.swift
@@ -29,8 +29,7 @@ public struct Op1Add: OpCodeProtocol {
     public var name: String { return "OP_1ADD" }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_1SUB.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_1SUB.swift
@@ -29,8 +29,7 @@ public struct Op1Sub: OpCodeProtocol {
     public var name: String { return "OP_1SUB" }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_2DIV.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_2DIV.swift
@@ -33,8 +33,7 @@ public struct Op2Div: OpCodeProtocol {
     }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_2MUL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_2MUL.swift
@@ -33,8 +33,7 @@ public struct Op2Mul: OpCodeProtocol {
     }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_ABS.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_ABS.swift
@@ -30,8 +30,7 @@ public struct OpAbsolute: OpCodeProtocol {
     public var name: String { return "OP_ABS" }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_ADD.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_ADD.swift
@@ -29,8 +29,7 @@ public struct OpAdd: OpCodeProtocol {
     public var name: String { return "OP_ADD" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_BOOLAND.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_BOOLAND.swift
@@ -29,8 +29,7 @@ public struct OpBoolAnd: OpCodeProtocol {
     public var name: String { return "OP_BOOLAND" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = context.data(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_BOOLOR.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_BOOLOR.swift
@@ -29,8 +29,7 @@ public struct OpBoolOr: OpCodeProtocol {
     public var name: String { return "OP_BOOLOR" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = context.data(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_DIV.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_DIV.swift
@@ -29,8 +29,7 @@ public struct OpDiv: OpCodeProtocol {
     public var name: String { return "OP_DIV" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_GREATERTHAN.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_GREATERTHAN.swift
@@ -29,8 +29,7 @@ public struct OpGreaterThan: OpCodeProtocol {
     public var name: String { return "OP_GREATERTHAN" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_GREATERTHANOREQUAL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_GREATERTHANOREQUAL.swift
@@ -29,8 +29,7 @@ public struct OpGreaterThanOrEqual: OpCodeProtocol {
     public var name: String { return "OP_GREATERTHANOREQUAL" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_LESSTHAN.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_LESSTHAN.swift
@@ -29,8 +29,7 @@ public struct OpLessThan: OpCodeProtocol {
     public var name: String { return "OP_LESSTHAN" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_LESSTHANOREQUAL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_LESSTHANOREQUAL.swift
@@ -29,8 +29,7 @@ public struct OpLessThanOrEqual: OpCodeProtocol {
     public var name: String { return "OP_LESSTHANOREQUAL" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_LSHIFT.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_LSHIFT.swift
@@ -33,8 +33,7 @@ public struct OpLShift: OpCodeProtocol {
     }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MAX.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MAX.swift
@@ -30,8 +30,7 @@ public struct OpMax: OpCodeProtocol {
     public var name: String { return "OP_MAX" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MIN.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MIN.swift
@@ -30,8 +30,7 @@ public struct OpMin: OpCodeProtocol {
     public var name: String { return "OP_MIN" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MOD.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MOD.swift
@@ -29,8 +29,7 @@ public struct OpMod: OpCodeProtocol {
     public var name: String { return "OP_MOD" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MUL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_MUL.swift
@@ -33,8 +33,7 @@ public struct OpMul: OpCodeProtocol {
     }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NEGATE.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NEGATE.swift
@@ -29,8 +29,7 @@ public struct OpNegate: OpCodeProtocol {
     public var name: String { return "OP_NEGATE" }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NOT.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NOT.swift
@@ -29,8 +29,7 @@ public struct OpNot: OpCodeProtocol {
     public var name: String { return "OP_NOT" }
 
     // (in -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let input = try context.number(at: -1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMEQUAL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMEQUAL.swift
@@ -29,8 +29,7 @@ public struct OpNumEqual: OpCodeProtocol {
     public var name: String { return "OP_NUMEQUAL" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMEQUALVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMEQUALVERIFY.swift
@@ -31,9 +31,9 @@ public struct OpNumEqualVerify: OpCodeProtocol {
     // input : x1 x2
     // output : - / fail
      public func mainProcess(_ context: ScriptExecutionContext) throws {
-        try OpCode.OP_NUMEQUAL.execute(context)
+        try OpCode.OP_NUMEQUAL.mainProcess(context)
         do {
-            try OpCode.OP_VERIFY.execute(context)
+            try OpCode.OP_VERIFY.mainProcess(context)
         } catch {
             throw OpCodeExecutionError.error("OP_NUMEQUALVERIFY failed.")
         }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMEQUALVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMEQUALVERIFY.swift
@@ -30,8 +30,7 @@ public struct OpNumEqualVerify: OpCodeProtocol {
 
     // input : x1 x2
     // output : - / fail
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try OpCode.OP_NUMEQUAL.execute(context)
         do {
             try OpCode.OP_VERIFY.execute(context)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMNOTEQUAL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_NUMNOTEQUAL.swift
@@ -29,8 +29,7 @@ public struct OpNumNotEqual: OpCodeProtocol {
     public var name: String { return "OP_NUMNOTEQUAL" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_RSHIFT.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_RSHIFT.swift
@@ -33,8 +33,7 @@ public struct OpRShift: OpCodeProtocol {
     }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_SUB.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_SUB.swift
@@ -29,8 +29,7 @@ public struct OpSub: OpCodeProtocol {
     public var name: String { return "OP_SUB" }
 
     // (x1 x2 -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = try context.number(at: -2)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_WITHIN.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/Numeric/OP_WITHIN.swift
@@ -29,8 +29,7 @@ public struct OpWithin: OpCodeProtocol {
     public var name: String { return "OP_WITHIN" }
 
     // (x1 min max -- out)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(3)
 
         let x = try context.number(at: -3)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_0.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_0.swift
@@ -31,8 +31,7 @@ public struct Op0: OpCodeProtocol {
 
     // input : -
     // output : n
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.pushToStack(0)
     }
 }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_1NEGATE.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_1NEGATE.swift
@@ -30,8 +30,7 @@ public struct Op1Negate: OpCodeProtocol {
     public var name: String { return "OP_1NEGATE" }
     // input : -
     // output : -1
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.pushToStack(-1)
     }
 }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKMULTISIG.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKMULTISIG.swift
@@ -38,8 +38,7 @@ public struct OpCheckMultiSig: OpCodeProtocol {
 
     // input : x sig1 sig2 ... <number of signatures> pub1 pub2 <number of public keys>
     // output : true / false
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
 
         // Get numPublicKeys with validation
         try context.assertStackHeightGreaterThan(1)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKMULTISIGVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKMULTISIGVERIFY.swift
@@ -31,8 +31,7 @@ public struct OpCheckMultiSigVerify: OpCodeProtocol {
 
     // input : x sig1 sig2 ... <number of signatures> pub1 pub2 <number of public keys>
     // output : Nothing / fail
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try OpCode.OP_CHECKMULTISIG.execute(context)
         do {
             try OpCode.OP_VERIFY.execute(context)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKMULTISIGVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKMULTISIGVERIFY.swift
@@ -32,9 +32,9 @@ public struct OpCheckMultiSigVerify: OpCodeProtocol {
     // input : x sig1 sig2 ... <number of signatures> pub1 pub2 <number of public keys>
     // output : Nothing / fail
      public func mainProcess(_ context: ScriptExecutionContext) throws {
-        try OpCode.OP_CHECKMULTISIG.execute(context)
+        try OpCode.OP_CHECKMULTISIG.mainProcess(context)
         do {
-            try OpCode.OP_VERIFY.execute(context)
+            try OpCode.OP_VERIFY.mainProcess(context)
         } catch {
             throw OpCodeExecutionError.error("OP_CHECKMULTISIGVERIFY failed.")
         }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKSIG.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKSIG.swift
@@ -31,8 +31,7 @@ public struct OpCheckSig: OpCodeProtocol {
 
     // input : sig pubkey
     // output : true / false
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let pubkeyData: Data = context.stack.removeLast()

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKSIGVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKSIGVERIFY.swift
@@ -32,9 +32,9 @@ public struct OpCheckSigVerify: OpCodeProtocol {
     // input : sig pubkey
     // output : Nothing / fail
      public func mainProcess(_ context: ScriptExecutionContext) throws {
-        try OpCode.OP_CHECKSIG.execute(context)
+        try OpCode.OP_CHECKSIG.mainProcess(context)
         do {
-            try OpCode.OP_VERIFY.execute(context)
+            try OpCode.OP_VERIFY.mainProcess(context)
         } catch {
             throw OpCodeExecutionError.error("OP_CHECKSIGVERIFY failed.")
         }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKSIGVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_CHECKSIGVERIFY.swift
@@ -31,8 +31,7 @@ public struct OpCheckSigVerify: OpCodeProtocol {
 
     // input : sig pubkey
     // output : Nothing / fail
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try OpCode.OP_CHECKSIG.execute(context)
         do {
             try OpCode.OP_VERIFY.execute(context)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_DUP.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_DUP.swift
@@ -31,8 +31,7 @@ public struct OpDuplicate: OpCodeProtocol {
 
     // input : x
     // output : x x
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
         try context.pushToStack(context.data(at: -1))
     }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EQUAL.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EQUAL.swift
@@ -31,8 +31,7 @@ public struct OpEqual: OpCodeProtocol {
 
     // input : x1 x2
     // output : true / false
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
 
         let x1 = context.stack.popLast()!

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EQUALVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EQUALVERIFY.swift
@@ -32,9 +32,9 @@ public struct OpEqualVerify: OpCodeProtocol {
     // input : x1 x2
     // output : - / fail
      public func mainProcess(_ context: ScriptExecutionContext) throws {
-        try OpCode.OP_EQUAL.execute(context)
+        try OpCode.OP_EQUAL.mainProcess(context)
         do {
-            try OpCode.OP_VERIFY.execute(context)
+            try OpCode.OP_VERIFY.mainProcess(context)
         } catch {
             throw OpCodeExecutionError.error("OP_CHECKSIGVERIFY failed.")
         }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EQUALVERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EQUALVERIFY.swift
@@ -31,8 +31,7 @@ public struct OpEqualVerify: OpCodeProtocol {
 
     // input : x1 x2
     // output : - / fail
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try OpCode.OP_EQUAL.execute(context)
         do {
             try OpCode.OP_VERIFY.execute(context)

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EXAMPLE.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_EXAMPLE.swift
@@ -28,9 +28,4 @@ import Foundation
 public class OpExample: OpCodeProtocol {
     public var value: UInt8 { return 0x00 }
     public var name: String { return "OP_EXAMPLE" }
-
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
-        // do something with context here!
-    }
 }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_HASH160.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_HASH160.swift
@@ -31,8 +31,7 @@ public struct OpHash160: OpCodeProtocol {
 
     // input : in
     // output : hash
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
 
         let data: Data = context.stack.removeLast()

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_N.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_N.swift
@@ -38,8 +38,7 @@ public struct OpN: OpCodeProtocol {
 
     // input : -
     // output : n
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.pushToStack(Int32(n))
     }
 }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_RETURN.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_RETURN.swift
@@ -28,8 +28,7 @@ public struct OpReturn: OpCodeProtocol {
     public var value: UInt8 { return 0x6a }
     public var name: String { return "OP_RETURN" }
 
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+     public func mainProcess(_ context: ScriptExecutionContext) throws {
         throw ScriptError.error("OP_RETURN was encountered")
     }
 }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_SWAP.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_SWAP.swift
@@ -30,8 +30,7 @@ public struct OpSwap: OpCodeProtocol {
     public var name: String { return "OP_SWAP" }
 
     // (x1 x2 -- x2 x1)
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(2)
         context.swapDataAt(i: -2, j: -1)
     }

--- a/BitcoinCashKit/Core/Scripts/OP_CODE/OP_VERIFY.swift
+++ b/BitcoinCashKit/Core/Scripts/OP_CODE/OP_VERIFY.swift
@@ -31,8 +31,7 @@ public struct OpVerify: OpCodeProtocol {
 
     // input : true / false
     // output : - / fail
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try prepareExecute(context)
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
         try context.assertStackHeightGreaterThan(1)
         guard context.bool(at: -1) else {
             throw OpCodeExecutionError.error("OP_VERIFY failed.")

--- a/BitcoinCashKit/Core/Scripts/OpCodeProtocol.swift
+++ b/BitcoinCashKit/Core/Scripts/OpCodeProtocol.swift
@@ -30,7 +30,6 @@ public protocol OpCodeProtocol {
 
     func isEnabled() -> Bool
     func mainProcess(_ context: ScriptExecutionContext) throws
-    func execute(_ context: ScriptExecutionContext) throws
 }
 
 extension OpCodeProtocol {

--- a/BitcoinCashKit/Core/Scripts/OpCodeProtocol.swift
+++ b/BitcoinCashKit/Core/Scripts/OpCodeProtocol.swift
@@ -57,7 +57,7 @@ extension OpCodeProtocol {
     }
 
     public func mainProcess(_ context: ScriptExecutionContext) throws {
-        throw OpCodeExecutionError.notImplemented
+        throw OpCodeExecutionError.notImplemented("[\(name)(\(value))]")
     }
 
     public func execute(_ context: ScriptExecutionContext) throws {
@@ -68,7 +68,7 @@ extension OpCodeProtocol {
 }
 
 public enum OpCodeExecutionError: Error {
-    case notImplemented
+    case notImplemented(String)
     case error(String)
     case opcodeRequiresItemsOnStack(Int)
     case invalidBignum

--- a/BitcoinCashKit/Core/Scripts/OpCodeProtocol.swift
+++ b/BitcoinCashKit/Core/Scripts/OpCodeProtocol.swift
@@ -29,6 +29,7 @@ public protocol OpCodeProtocol {
     var value: UInt8 { get }
 
     func isEnabled() -> Bool
+    func mainProcess(_ context: ScriptExecutionContext) throws
     func execute(_ context: ScriptExecutionContext) throws
 }
 
@@ -36,21 +37,33 @@ extension OpCodeProtocol {
     public func isEnabled() -> Bool {
         return true
     }
-
-    public func prepareExecute(_ context: ScriptExecutionContext) throws {
+    private func preprocess(_ context: ScriptExecutionContext) throws {
         guard isEnabled() else {
             throw OpCodeExecutionError.disabled
         }
         if context.verbose {
-            print("[prepare execution : \(name)(\(value))]")
+            print("[pre execution : \(name)(\(value))]")
             print(context)
         }
         try context.incrementOpCount()
-        // if context.verbose == true, print stacks and so on...
+
+    }
+
+    private func postProcess(_ context: ScriptExecutionContext) {
+        if context.verbose {
+            print("[post execution : \(name)(\(value))]")
+            print(context)
+        }
+    }
+
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
+        throw OpCodeExecutionError.notImplemented
     }
 
     public func execute(_ context: ScriptExecutionContext) throws {
-        throw OpCodeExecutionError.notImplemented
+        try preprocess(context)
+        try mainProcess(context)
+        postProcess(context)
     }
 }
 

--- a/BitcoinCashKit/Core/Scripts/Opcode.swift
+++ b/BitcoinCashKit/Core/Scripts/Opcode.swift
@@ -180,10 +180,6 @@ public enum OpCode: OpCodeProtocol {
     public func mainProcess(_ context: ScriptExecutionContext) throws {
         try opcode.mainProcess(context)
     }
-
-    public func execute(_ context: ScriptExecutionContext) throws {
-        try opcode.execute(context)
-    }
 }
 
 //public struct OpCode {

--- a/BitcoinCashKit/Core/Scripts/Opcode.swift
+++ b/BitcoinCashKit/Core/Scripts/Opcode.swift
@@ -177,6 +177,10 @@ public enum OpCode: OpCodeProtocol {
         return opcode.isEnabled()
     }
 
+    public func mainProcess(_ context: ScriptExecutionContext) throws {
+        try opcode.mainProcess(context)
+    }
+
     public func execute(_ context: ScriptExecutionContext) throws {
         try opcode.execute(context)
     }


### PR DESCRIPTION
## Abstract
For each OP_CODEs, we should implement `mainProcess()`.

```
public protocol OpCodeProtocol {
    var name: String { get }
    var value: UInt8 { get }

    func isEnabled() -> Bool
    func mainProcess(_ context: ScriptExecutionContext) throws
}

extension OpCodeProtocol {
    private func preprocess(_ context: ScriptExecutionContext) throws { ... }

    private func postProcess(_ context: ScriptExecutionContext) { ... }

    public func mainProcess(_ context: ScriptExecutionContext) throws {
        throw OpCodeExecutionError.notImplemented("[\(name)(\(value))]")
    }

    public func execute(_ context: ScriptExecutionContext) throws {
        try preprocess(context)
        try mainProcess(context)
        postProcess(context)
    }
}
```