### PR TITLE
:recycle: make access modifiers of extensions public

### DIFF
--- a/BitcoinCashKit/Core/SighashType.swift
+++ b/BitcoinCashKit/Core/SighashType.swift
@@ -77,14 +77,14 @@ public struct SighashType {
     }
 }
 
-public extension UInt8 {
-    init(_ hashType: SighashType) {
+extension UInt8 {
+    public init(_ hashType: SighashType) {
         self = hashType.uint8
     }
 }
 
 public extension UInt32 {
-    init(_ hashType: SighashType) {
+    public init(_ hashType: SighashType) {
         self = UInt32(UInt8(hashType))
     }
 }

--- a/BitcoinCashKit/Core/SighashType.swift
+++ b/BitcoinCashKit/Core/SighashType.swift
@@ -77,13 +77,13 @@ public struct SighashType {
     }
 }
 
-extension UInt8 {
+public extension UInt8 {
     init(_ hashType: SighashType) {
         self = hashType.uint8
     }
 }
 
-extension UInt32 {
+public extension UInt32 {
     init(_ hashType: SighashType) {
         self = UInt32(UInt8(hashType))
     }

--- a/BitcoinCashKit/Core/SighashType.swift
+++ b/BitcoinCashKit/Core/SighashType.swift
@@ -83,7 +83,7 @@ extension UInt8 {
     }
 }
 
-public extension UInt32 {
+extension UInt32 {
     public init(_ hashType: SighashType) {
         self = UInt32(UInt8(hashType))
     }


### PR DESCRIPTION
close #328 

Made access modifiers of `UInt8` and `Uint32` `public`